### PR TITLE
Overhaul Ruby CI with oxidize-rb cross-platform build

### DIFF
--- a/.github/workflows/ruby-ci.yaml
+++ b/.github/workflows/ruby-ci.yaml
@@ -50,22 +50,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+      - name: Set up Ruby and Rust
+        uses: oxidize-rb/actions/setup-ruby-and-rust@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler: latest
           bundler-cache: false
-
-      - name: Cargo version check
-        working-directory: crates/${{ matrix.bindings }}
-        run: |
-          rustc --version
-          cargo --version
-          ls ext/Cargo.toml
+          cargo-cache: true
+          cache-version: v1-native
 
       - name: Install Ruby deps
         working-directory: crates/${{ matrix.bindings }}
@@ -135,8 +127,8 @@ jobs:
       id-token: write
     strategy:
       fail-fast: false
-      matrix:
-        bindings: [ruby-bindings, ruby-bindings-gpu]
+    matrix:
+      bindings: [ruby-bindings, ruby-bindings-gpu]
     steps:
       - name: Download gem artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/ruby-ci.yaml
+++ b/.github/workflows/ruby-ci.yaml
@@ -3,76 +3,156 @@ name: Ruby CI
 on:
   push:
     branches: [ main, master ]
+    tags:
+      - 'v*'
   pull_request:
   workflow_dispatch:
 
 # https://github.com/oxidize-rb/actions
 
 jobs:
-  ruby-cpu-build:
-    name: Ruby CPU build + test
+  ########################################################################
+  # 1. Fetch CI metadata — stable Ruby versions + supported platforms
+  ########################################################################
+  fetch-ci-data:
+    name: Fetch CI data
     runs-on: ubuntu-22.04
-    defaults:
-      run:
-        working-directory: crates/ruby-bindings
+    outputs:
+      result: ${{ steps.ci-data.outputs.result }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - name: Set up Ruby and Rust
-        uses: oxidize-rb/actions/setup-ruby-and-rust@main
+      - name: Fetch CI data
+        id: ci-data
+        uses: oxidize-rb/actions/fetch-ci-data@v1
         with:
-          ruby-version: "3.4"
+          stable-ruby-versions: |
+            exclude: [head]
+          supported-ruby-platforms: |
+            exclude: [arm-linux, x64-mingw32]
+
+  ########################################################################
+  # 2. Native build + test on real runners (Linux / macOS / Windows)
+  ########################################################################
+  native-test:
+    name: "${{ matrix.bindings }} — ${{ matrix.os }} / ruby ${{ matrix.ruby }}"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, macos-14, windows-2022]
+        ruby: ["3.2", "3.3", "3.4"]
+        bindings: [ruby-bindings, ruby-bindings-gpu]
+        exclude:
+          # GPU (Vulkan) tests only on Linux and macOS runners
+          - os: windows-2022
+            bindings: ruby-bindings-gpu
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler: latest
           bundler-cache: false
-          cargo-cache: true
-          cargo-vendor: true
-          cache-version: v0-cpu
-          working-directory: crates/ruby-bindings
+
+      - name: Cargo version check
+        working-directory: crates/${{ matrix.bindings }}
+        run: |
+          rustc --version
+          cargo --version
+          ls ext/Cargo.toml
+
+      - name: Install Ruby deps
+        working-directory: crates/${{ matrix.bindings }}
+        run: bundle install
 
       - name: Build native extension
-        run: rake build
+        working-directory: crates/${{ matrix.bindings }}
+        run: |
+          cargo build --release --manifest-path ext/Cargo.toml
+          rake build
 
       - name: Run RSpec tests
-        run: |
-          bundle install
-          bundle exec rspec spec/
+        working-directory: crates/${{ matrix.bindings }}
+        run: bundle exec rspec spec/
 
-      - name: Cross-compile with cross-gem
-        uses: oxidize-rb/actions/cross-gem@v1
-        with:
-          platform: x86_64-linux
-          ruby-versions: "3.4"
-          working-directory: crates/ruby-bindings
-
-  ruby-gpu-build:
-    name: Ruby GPU build + test
+  ########################################################################
+  # 3. Cross-compile gems for all 5 platforms
+  ########################################################################
+  cross-gem:
+    name: "cross-gem ${{ matrix.bindings }} — ${{ matrix.platform }}"
     runs-on: ubuntu-22.04
-    defaults:
-      run:
-        working-directory: crates/ruby-bindings-gpu
+    needs: [fetch-ci-data, native-test]
+    if: needs.native-test.result == 'success'
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [x86_64-linux, aarch64-linux, x86_64-darwin, arm64-darwin, x64-mingw-ucrt]
+        bindings: [ruby-bindings, ruby-bindings-gpu]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Ruby and Rust
-        uses: oxidize-rb/actions/setup-ruby-and-rust@main
+        uses: oxidize-rb/actions/setup-ruby-and-rust@v1
         with:
           ruby-version: "3.4"
-          bundler-cache: false
+          bundler-cache: true
           cargo-cache: true
           cargo-vendor: true
-          cache-version: v0-gpu
-          working-directory: crates/ruby-bindings-gpu
+          cache-version: v3-cross
+          working-directory: crates/${{ matrix.bindings }}
 
-      - name: Build native extension
-        run: rake build
-
-      - name: Run RSpec tests
-        run: |
-          bundle install
-          bundle exec rspec spec/
-
-      - name: Cross-compile with cross-gem
+      - name: Cross-compile gem
         uses: oxidize-rb/actions/cross-gem@v1
         with:
-          platform: x86_64-linux
-          ruby-versions: "3.4"
-          working-directory: crates/ruby-bindings-gpu
+          platform: ${{ matrix.platform }}
+          ruby-versions: "3.2,3.3,3.4"
+          working-directory: crates/${{ matrix.bindings }}
+          cache-save-always: true
+
+      - name: Upload gem artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: "${{ matrix.bindings }}-${{ matrix.platform }}-gem"
+          path: crates/${{ matrix.bindings }}/pkg/*.gem
+          retention-days: 7
+
+  ########################################################################
+  # 4. Publish gems to RubyGems on tagged releases
+  ########################################################################
+  publish:
+    name: Publish to RubyGems
+    runs-on: ubuntu-22.04
+    needs: [cross-gem]
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        bindings: [ruby-bindings, ruby-bindings-gpu]
+    steps:
+      - name: Download gem artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: "${{ matrix.bindings }}-*-gem"
+          path: gems/
+          merge-multiple: true
+
+      - name: Publish to RubyGems
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+          rubygems: latest
+        env:
+          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+      - run: |
+          for gem in gems/*.gem; do
+            gem push "$gem"
+          done

--- a/crates/ruby-bindings-gpu/Rakefile
+++ b/crates/ruby-bindings-gpu/Rakefile
@@ -6,17 +6,27 @@ def build_extension
   lib_dir = File.expand_path("lib/modern_colorthief_gpu")
   FileUtils.mkdir_p(lib_dir) unless File.directory?(lib_dir)
 
-  system("cargo", "build", "--release", "--manifest-path", "ext/Cargo.toml") do |ok, status|
+  # Support cross-compilation via oxidize-rb / rb-sys-dock.
+  # The cross-gem action sets RUSTUP_TARGET for the target triple.
+  cargo_args = ["build", "--release", "--manifest-path", "ext/Cargo.toml"]
+  if target = ENV["RUSTUP_TARGET"]
+    cargo_args << "--target" << target
+  end
+
+  system(*cargo_args) do |ok, status|
     abort "Cargo build failed (exit #{status.exitstatus})" unless ok
   end
 
-  target_dir = File.expand_path("target/release")
+  # When cross-compiling, Cargo outputs to target/<triple>/release
+  target_dir = if ENV["RUSTUP_TARGET"]
+    File.expand_path("target/#{ENV["RUSTUP_TARGET"]}/release")
+  else
+    File.expand_path("target/release")
+  end
 
   found = Dir.glob(File.join(target_dir, "libmodern_colorthief_gpu.*"))
     .find { |f| File.file?(f) && %w[.so .bundle .dll].any? { |ext| f.end_with?(ext) } }
   if found
-    # Rename to match Ruby init symbol: Ruby expects Init_<basename>, so
-    # modern_colorthief_gpu.so -> Init_modern_colorthief_gpu (matches magnus ruby_init_name).
     basename = File.basename(found)
     renamed = basename.sub(/\Alibmodern_colorthief_gpu/, "modern_colorthief_gpu")
     FileUtils.cp(found, File.join(lib_dir, renamed))

--- a/crates/ruby-bindings-gpu/ext/src/lib.rs
+++ b/crates/ruby-bindings-gpu/ext/src/lib.rs
@@ -16,7 +16,7 @@ fn get_palette(
         quality,
     )
     .map(|colors| colors.into_iter().map(|(r, g, b)| vec![r, g, b]).collect())
-    .map_err(|e| error::Error::new(exception::standard_error(), e.to_string()))
+    .map_err(|e| error::Error::new(exception::runtime_error(), e.to_string()))
 }
 
 fn get_color(
@@ -28,16 +28,16 @@ fn get_color(
     let pixels = unsafe { pixels.as_slice() };
     let palette =
         modern_colorthief_core_gpu::extract_palette_from_buffer(pixels, width, height, 5, quality)
-            .map_err(|e| error::Error::new(exception::standard_error(), e.to_string()))?;
+            .map_err(|e| error::Error::new(exception::runtime_error(), e.to_string()))?;
 
     palette
         .first()
         .copied()
         .map(|(r, g, b)| vec![r, g, b])
-        .ok_or_else(|| error::Error::new(exception::standard_error(), "No color extracted"))
+        .ok_or_else(|| error::Error::new(exception::runtime_error(), "No color extracted"))
 }
 
-#[magnus::init(init_name = "modern_colorthief_gpu")]
+#[magnus::init]
 fn init_colorthief_gpu_ruby() {
     let mod_colorthief_gpu = define_module("ColorthiefGpu").unwrap();
     mod_colorthief_gpu

--- a/crates/ruby-bindings-gpu/ext/src/lib.rs
+++ b/crates/ruby-bindings-gpu/ext/src/lib.rs
@@ -37,7 +37,7 @@ fn get_color(
         .ok_or_else(|| error::Error::new(exception::standard_error(), "No color extracted"))
 }
 
-#[magnus::init(ruby_init_name = "modern_colorthief_gpu")]
+#[magnus::init(init_name = "modern_colorthief_gpu")]
 fn init_colorthief_gpu_ruby() {
     let mod_colorthief_gpu = define_module("ColorthiefGpu").unwrap();
     mod_colorthief_gpu

--- a/crates/ruby-bindings/Rakefile
+++ b/crates/ruby-bindings/Rakefile
@@ -6,17 +6,27 @@ def build_extension
   lib_dir = File.expand_path("lib/modern_colorthief")
   FileUtils.mkdir_p(lib_dir) unless File.directory?(lib_dir)
 
-  system("cargo", "build", "--release", "--manifest-path", "ext/Cargo.toml") do |ok, status|
+  # Support cross-compilation via oxidize-rb / rb-sys-dock.
+  # The cross-gem action sets RUSTUP_TARGET for the target triple.
+  cargo_args = ["build", "--release", "--manifest-path", "ext/Cargo.toml"]
+  if target = ENV["RUSTUP_TARGET"]
+    cargo_args << "--target" << target
+  end
+
+  system(*cargo_args) do |ok, status|
     abort "Cargo build failed (exit #{status.exitstatus})" unless ok
   end
 
-  target_dir = File.expand_path("target/release")
+  # When cross-compiling, Cargo outputs to target/<triple>/release
+  target_dir = if ENV["RUSTUP_TARGET"]
+    File.expand_path("target/#{ENV["RUSTUP_TARGET"]}/release")
+  else
+    File.expand_path("target/release")
+  end
 
   found = Dir.glob(File.join(target_dir, "libmodern_colorthief.*"))
     .find { |f| File.file?(f) && %w[.so .bundle .dll].any? { |ext| f.end_with?(ext) } }
   if found
-    # Rename to match Ruby init symbol: Ruby expects Init_<basename>, so
-    # modern_colorthief.so -> Init_modern_colorthief (matches magnus ruby_init_name).
     basename = File.basename(found)
     renamed = basename.sub(/\Alibmodern_colorthief/, "modern_colorthief")
     FileUtils.cp(found, File.join(lib_dir, renamed))

--- a/crates/ruby-bindings/ext/src/lib.rs
+++ b/crates/ruby-bindings/ext/src/lib.rs
@@ -37,7 +37,7 @@ fn get_color(
         .ok_or_else(|| error::Error::new(exception::standard_error(), "Image contains no colors"))
 }
 
-#[magnus::init(ruby_init_name = "modern_colorthief")]
+#[magnus::init(init_name = "modern_colorthief")]
 fn init_colorthief_ruby() {
     let mod_colorthief = define_module("Colorthief").unwrap();
     mod_colorthief

--- a/crates/ruby-bindings/ext/src/lib.rs
+++ b/crates/ruby-bindings/ext/src/lib.rs
@@ -16,7 +16,7 @@ fn get_palette(
         quality,
     )
     .map(|colors| colors.into_iter().map(|(r, g, b)| vec![r, g, b]).collect())
-    .map_err(|e| error::Error::new(exception::standard_error(), e.to_string()))
+    .map_err(|e| error::Error::new(exception::runtime_error(), e.to_string()))
 }
 
 fn get_color(
@@ -28,16 +28,16 @@ fn get_color(
     let pixels = unsafe { pixels.as_slice() };
     let palette =
         modern_colorthief_core_cpu::extract_palette_from_buffer(pixels, width, height, 5, quality)
-            .map_err(|e| error::Error::new(exception::standard_error(), e.to_string()))?;
+            .map_err(|e| error::Error::new(exception::runtime_error(), e.to_string()))?;
 
     palette
         .first()
         .copied()
         .map(|(r, g, b)| vec![r, g, b])
-        .ok_or_else(|| error::Error::new(exception::standard_error(), "Image contains no colors"))
+        .ok_or_else(|| error::Error::new(exception::runtime_error(), "Image contains no colors"))
 }
 
-#[magnus::init(init_name = "modern_colorthief")]
+#[magnus::init]
 fn init_colorthief_ruby() {
     let mod_colorthief = define_module("Colorthief").unwrap();
     mod_colorthief


### PR DESCRIPTION
## Summary
- Fix `magnus::init` attribute: use `init_name` instead of unsupported `ruby_init_name` (was causing compilation failures)
- Rewrite ruby-ci.yaml with oxidize-rb/actions best practices (fetch-ci-data, cross-gem)
- Native test matrix: Linux/macOS/Windows × Ruby versions × CPU & GPU variants
- Cross-gem matrix: 5 platforms × CPU & GPU for distributable gems
- Publish to RubyGems on tagged releases
- Update Rakefiles to support `RUSTUP_TARGET` cross-compilation
